### PR TITLE
Add support for async imports

### DIFF
--- a/examples/babel-cjs/src/index.mjs
+++ b/examples/babel-cjs/src/index.mjs
@@ -3,6 +3,10 @@ import * as mod from "./dir/mod";
 
 export * from "./dir/mod";
 
+async function foo() {
+	const foo = await import("./dir/mod");
+}
+
 for(const x of [[1, 2], 3, [4, 5]].flat())
 {
 	mod.foo(x);

--- a/examples/babel-esm/src/index.mjs
+++ b/examples/babel-esm/src/index.mjs
@@ -3,6 +3,10 @@ import * as mod from "./dir/mod";
 
 export * from "./dir/mod";
 
+async function foo() {
+	const foo = await import("./dir/mod");
+}
+
 for(const x of [[1, 2], 3, [4, 5]].flat())
 {
 	mod.foo(x);

--- a/examples/ts-babel-cjs/src/index.ts
+++ b/examples/ts-babel-cjs/src/index.ts
@@ -3,6 +3,10 @@ import * as mod from "./dir/mod";
 
 export * from "./dir/mod";
 
+async function foo() {
+	const foo = await import("./dir/mod");
+}
+
 for(const x of [[1, 2], 3, [4, 5]].flat())
 {
 	mod.foo(x);

--- a/examples/ts-babel-cjs/tsconfig.json
+++ b/examples/ts-babel-cjs/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "removeComments": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ESNext",
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "*.d.ts"
+  ]
+}

--- a/examples/ts-babel-esm/src/index.ts
+++ b/examples/ts-babel-esm/src/index.ts
@@ -1,7 +1,12 @@
+
 import "./dir";
 import * as mod from "./dir/mod";
 
 export * from "./dir/mod";
+
+async function foo() {
+	const foo = await import("./dir/mod");
+}
 
 for(const x of [[1, 2], 3, [4, 5]].flat())
 {

--- a/examples/ts-babel-esm/tsconfig.json
+++ b/examples/ts-babel-esm/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "emitDecoratorMetadata": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "removeComments": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ESNext",
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "*.d.ts"
+  ]
+}

--- a/examples/ts-tsc-cjs/src/index.ts
+++ b/examples/ts-tsc-cjs/src/index.ts
@@ -5,6 +5,10 @@ import * as mod from "./dir/mod";
 
 export * from "./dir/mod";
 
+async function foo() {
+	const foo = await import("./dir/mod");
+}
+
 for(const x of [[1, 2], 3, [4, 5]].flat())
 {
 	mod.foo(x);

--- a/examples/ts-tsc-esm/src/index.ts
+++ b/examples/ts-tsc-esm/src/index.ts
@@ -5,6 +5,10 @@ import * as mod from "./dir/mod";
 
 export * from "./dir/mod";
 
+async function foo() {
+	const foo = await import("./dir/mod");
+}
+
 for(const x of [[1, 2], 3, [4, 5]].flat())
 {
 	mod.foo(x);

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,13 +97,13 @@ export default (babel: Babel, options: Options): B.PluginObj<PluginPass> =>
 function handleCallExpression(types: BabelTypes, declaration: B.NodePath<B.types.CallExpression>, filename: string, options: Options): void
 {
 	const callee = declaration.get("callee");
-	if(!callee.isIdentifier())
+	if(!callee.isIdentifier() && !callee.isImport())
 	{
 		return;
 	}
-	if(callee.node.name !== "require")
+	if(callee.isIdentifier() && callee.node.name !== "require")
 	{
-		// do nothing if function name is not "require"
+		// do nothing if it's a function but not named "require"
 		return;
 	}
 	const args = declaration.get("arguments");


### PR DESCRIPTION
@shimataro, thanks for publishing this plugin. I found it quite useful. I did notice that it could not handle async imports. This PR adds support for asynchronous `import(...)`s. The behavior is identical to how this plugin handles `require(...)`.

Input:
```js
async function foo() {
	const foo = await import("./dir/mod");
}
```

Output
```js
async function foo() {
	const foo = await import("./dir/mod.js");
}
```

I hope that you and others can benefit from this small addition to the plugin. Let me know if you have any questions, or need this to be rebased/etc before you'll merge.